### PR TITLE
Deploy changes

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,49 +3,51 @@ const { ethers, run, network } = require("hardhat")
 
 // async main
 async function main() {
-  const SimpleStorageFactory = await ethers.getContractFactory("SimpleStorage")
-  console.log("Deploying contract...")
-  const simpleStorage = await SimpleStorageFactory.deploy()
-  await simpleStorage.deployed()
-  console.log(`Deployed contract to: ${simpleStorage.address}`)
-  // what happens when we deploy to our hardhat network?
-  if (network.config.chainId === 11155111 && process.env.ETHERSCAN_API_KEY) {
-    console.log("Waiting for block confirmations...")
-    await simpleStorage.deployTransaction.wait(6)
-    await verify(simpleStorage.address, [])
-  }
+    const SimpleStorageFactory = await ethers.getContractFactory(
+        "SimpleStorage"
+    )
+    console.log("Deploying contract...")
+    const simpleStorage = await SimpleStorageFactory.deploy()
+    await simpleStorage.waitForDeployment()
+    console.log(`Deployed contract to: ${simpleStorage.target}`)
+    // what happens when we deploy to our hardhat network?
+    if (network.config.chainId === 11155111 && process.env.ETHERSCAN_API_KEY) {
+        console.log("Waiting for block confirmations...")
+        await simpleStorage.deployTransaction.wait(6)
+        await verify(simpleStorage.address, [])
+    }
 
-  const currentValue = await simpleStorage.retrieve()
-  console.log(`Current Value is: ${currentValue}`)
+    const currentValue = await simpleStorage.retrieve()
+    console.log(`Current Value is: ${currentValue}`)
 
-  // Update the current value
-  const transactionResponse = await simpleStorage.store(7)
-  await transactionResponse.wait(1)
-  const updatedValue = await simpleStorage.retrieve()
-  console.log(`Updated Value is: ${updatedValue}`)
+    // Update the current value
+    const transactionResponse = await simpleStorage.store(7)
+    await transactionResponse.wait(1)
+    const updatedValue = await simpleStorage.retrieve()
+    console.log(`Updated Value is: ${updatedValue}`)
 }
 
 // async function verify(contractAddress, args) {
 const verify = async (contractAddress, args) => {
-  console.log("Verifying contract...")
-  try {
-    await run("verify:verify", {
-      address: contractAddress,
-      constructorArguments: args,
-    })
-  } catch (e) {
-    if (e.message.toLowerCase().includes("already verified")) {
-      console.log("Already Verified!")
-    } else {
-      console.log(e)
+    console.log("Verifying contract...")
+    try {
+        await run("verify:verify", {
+            address: contractAddress,
+            constructorArguments: args,
+        })
+    } catch (e) {
+        if (e.message.toLowerCase().includes("already verified")) {
+            console.log("Already Verified!")
+        } else {
+            console.log(e)
+        }
     }
-  }
 }
 
 // main
 main()
-  .then(() => process.exit(0))
-  .catch((error) => {
-    console.error(error)
-    process.exit(1)
-  })
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error)
+        process.exit(1)
+    })

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,28 +3,27 @@ const { ethers, run, network } = require("hardhat")
 
 // async main
 async function main() {
-    const SimpleStorageFactory = await ethers.getContractFactory(
-        "SimpleStorage"
-    )
-    console.log("Deploying contract...")
-    const simpleStorage = await SimpleStorageFactory.deploy()
-    await simpleStorage.waitForDeployment()
-    console.log(`Deployed contract to: ${simpleStorage.target}`)
-    // what happens when we deploy to our hardhat network?
-    if (network.config.chainId === 11155111 && process.env.ETHERSCAN_API_KEY) {
-        console.log("Waiting for block confirmations...")
-        await simpleStorage.deployTransaction.wait(6)
-        await verify(simpleStorage.address, [])
-    }
+  const SimpleStorageFactory = await ethers.getContractFactory("SimpleStorage")
+  console.log("Deploying contract...")
+  const simpleStorage = await SimpleStorageFactory.deploy()
+  await simpleStorage.waitForDeployment()
+  console.log(`Deployed contract to: ${simpleStorage.target}`)
+  
+  // what happens when we deploy to our hardhat network?
+  if (network.config.chainId === 11155111 && process.env.ETHERSCAN_API_KEY) {
+    console.log("Waiting for block confirmations...")
+    await simpleStorage.deployTransaction.wait(6)
+    await verify(simpleStorage.address, [])
+  }
 
-    const currentValue = await simpleStorage.retrieve()
-    console.log(`Current Value is: ${currentValue}`)
+  const currentValue = await simpleStorage.retrieve()
+  console.log(`Current Value is: ${currentValue}`)
 
-    // Update the current value
-    const transactionResponse = await simpleStorage.store(7)
-    await transactionResponse.wait(1)
-    const updatedValue = await simpleStorage.retrieve()
-    console.log(`Updated Value is: ${updatedValue}`)
+  // Update the current value
+  const transactionResponse = await simpleStorage.store(7)
+  await transactionResponse.wait(1)
+  const updatedValue = await simpleStorage.retrieve()
+  console.log(`Updated Value is: ${updatedValue}`)
 }
 
 // async function verify(contractAddress, args) {


### PR DESCRIPTION
Hey guys I made changes in the deploy.js
I used the functions compatible with hardhat-toolbox v3.0
I was getting errors when I used the old functions and I wasted a lot of time fixing them, so I thought to commit these changes so that this problem might not arise for other students
I added the .waitForDeployment() function instead of .deployed() which is now deprecated
I also added the .target to get the address instead of .address because it returned unidentified earlier